### PR TITLE
DeleteAll Fixes

### DIFF
--- a/Archivist.lua
+++ b/Archivist.lua
@@ -345,8 +345,8 @@ function Archivist:DeleteAll(storeType)
 			self.sv[id] = {}
 			self.activeStores[id] = {}
 		end
+		self.storeMap = {}
 	end
-	self.storeMap = {}
 end
 
 -- deactivates store, with one last opportunity to commit data if the prototype chooses to do so

--- a/Archivist.lua
+++ b/Archivist.lua
@@ -335,7 +335,7 @@ end
 -- Don't say I didn't warn you
 function Archivist:DeleteAll(storeType)
 	if storeType then
-		self.sv[storeType] = nil
+		self.sv[storeType] = {}
 		for id, store in pairs(self.activeStores[storeType]) do
 			self.activeStores[storeType][id] = nil
 			self.storeMap[store] = nil


### PR DESCRIPTION
Fixes #3, as well as a separate issue I noticed this morning.

With the included changes the following test case from #3 should now correctly work without error:

```lua
Archivist:Initialize({});
assert(Archivist.sv.ReadOnly);
Archivist:DeleteAll("ReadOnly");
assert(Archivist.sv.ReadOnly); -- Would previously fail as `self.sv.ReadOnly` would be nil.
Archivist:Create("ReadOnly", "TestStore1", "1");  -- Would previously error as `self.sv.ReadOnly` would be nil.
assert(Archivist.sv.ReadOnly.TestStore1 ~= nil);
```

An additional issue was fixed where `self.storeMap` was being cleared unconditionally for both branches in the DeleteAll method - this would result in an error if the user had multiple stores open from different types, called DeleteAll with a single named store type, and then tried to close a store from a different type.

```lua
Archivist:Initialize({});
assert(Archivist.sv.ReadOnly);
assert(Archivist.sv.RawData);
local TestStore3 = Archivist:Create("ReadOnly", "TestStore3", "3");
assert(Archivist.sv.ReadOnly.TestStore3 ~= nil);
local TestStore4 = Archivist:Create("RawData", "TestStore4", "4");
assert(Archivist.sv.RawData.TestStore4 ~= nil);
Archivist:DeleteAll("ReadOnly");
assert(Archivist.sv.ReadOnly);
assert(Archivist.sv.RawData);
Archivist:CloseStore(TestStore4); -- Would previously fail an assertion as `self.storeMap[TestStore4]` would be nil.
```
