### PR TITLE
Various fixes for the Delete store method

### DIFF
--- a/Archivist.lua
+++ b/Archivist.lua
@@ -143,7 +143,8 @@ function Archivist:RegisterStoreType(prototype)
 		Update = prototype.Update,
 		Open = prototype.Open,
 		Commit = prototype.Commit,
-		Close = prototype.Close
+		Close = prototype.Close,
+		Delete = prototype.Delete
 	}
 	self.activeStores[prototype.id] = self.activeStores[prototype.id] or {}
 	if self:IsInitialized() then
@@ -279,10 +280,10 @@ function Archivist:Delete(storeType, id, force)
 	end
 
 	if id and storeType and self.sv[storeType] then
-		if self.prototypes[id] and self.prototypes[id].Delete then
+		if self.prototypes[storeType] and self.prototypes[storeType].Delete and self.sv[storeType][id] then
 			local image = self.activeStores[storeType][id]
 						 and self:Close(self.activeStores[storeType][id])
-						 or self:Dearchive(self.sv[storeType][id])
+						 or self:DeArchive(self.sv[storeType][id].data)
 			self.prototypes[storeType]:Delete(image)
 		end
 		self.sv[storeType][id] = nil


### PR DESCRIPTION
The Delete store method had a few issues which prevented its initial implementation from actually working.

Firstly, the RegisterStoreType function wasn't copying the Delete method from the supplied prototype to the table it creates:

https://github.com/emptyrivers/Archivist/blob/097cccc4268254b7ae1eb6170fd3d54d885decbe/Archivist.lua#L138-L147

Next, the Delete verb was incorrectly indexing the prototypes table by the ID of the given store, instead of the store type:

https://github.com/emptyrivers/Archivist/blob/097cccc4268254b7ae1eb6170fd3d54d885decbe/Archivist.lua#L281-L283

Finally, with those two issues corrected there was a typo in the call to DeArchive which used a lowercase "A" and the parameter supplied to it was the saved variable table for the store, not the data field - so if the store wasn't open when being deleted, the DecodeForPrint function would error:

https://github.com/emptyrivers/Archivist/blob/097cccc4268254b7ae1eb6170fd3d54d885decbe/Archivist.lua#L285
