### PR TITLE
add wind/unwind functionality

### DIFF
--- a/Archivist.lua
+++ b/Archivist.lua
@@ -264,8 +264,7 @@ end
 -- produces storable data from image
 function proto:Wind(storeType, image)
 	do -- arg validation
-		self:Assert(type(storeType) == "string" and self.prototypes[storeType], "Store type must be registered before loading data.")
-		self:Assert(image ~= nil, "Cannot wind nil data")
+		self:Assert(type(storeType) == "string" and self.prototypes[storeType], "Store type must be registered before winding data.")
 	end
 
 	if self.prototypes[storeType].Wind then
@@ -277,8 +276,7 @@ end
 
 function proto:Unwind(storeType, woundImage)
 	do -- arg validation
-		self:Assert(type(storeType) == "string" and self.prototypes[storeType], "Store type must be registered before loading data.")
-		self:Assert(woundImage ~= nil, "Cannot unwind nil data")
+		self:Assert(type(storeType) == "string" and self.prototypes[storeType], "Store type must be registered before unwinding data.")
 	end
 
 	if self.prototypes[storeType].Unwind then

--- a/Archivist.lua
+++ b/Archivist.lua
@@ -404,7 +404,7 @@ function proto:Open(storeType, id, ...)
 	local store = self.activeStores[storeType][id]
 	if not store then
 		local saved = self.sv.stores[storeType][id]
-		local data = self:Unwind(saved.data)
+		local data = self:Unwind(storeType, saved.data)
 		local prototype = self.prototypes[storeType]
 		-- migrate data...
 		if prototype.Update and prototype.version > saved.version then

--- a/Archivist.lua
+++ b/Archivist.lua
@@ -184,6 +184,8 @@ local function checkPrototype(prototype)
 	Archivist:Assert(type(prototype.Commit) == "function", "Invalid prototype field 'Commit': Expected function, got %q instead.", type(prototype.Commit))
 	Archivist:Assert(type(prototype.Close) == "function", "Invalid prototype field 'Close': Expected function, got %q instead.", type(prototype.Close))
 	Archivist:Assert(prototype.Delete == nil or type(prototype.Delete) == "function", "Invalid prototype field 'Delete': Expected function, got %q instead.", type(prototype.Delete))
+	Archivist:Assert(prototype.Wind == nil or type(prototype.Wind) == "function", "Invalid prototype field 'Wind': Expected function, got %q instead.", type(prototype.Wind))
+	Archivist:Assert(type(prototype.Wind) == type(prototype.Unwind), "Mismatched prototype fields 'Wind'/'Unwind': Expected nil/nil or function/function, got %q/%q instead.", type(prototype.Wind), type(prototype.Unwind))
 end
 
 -- Register a default store type, which is registered with all initialized archives simultaneously
@@ -214,7 +216,9 @@ end
 --  Commit - function (required). Return an image of the data that should be archived.
 --  Close - function (required). Release ownership of active store object. Optionally, return image of data to write into archive.
 --  Delete - function (optional). If provided, called when a store is deleted. Useful for cleaning up sub stores.
--- Please note that Create, Open, Update, Commit, Close, Delete may be called at any time if Archivist deems it necessary.
+--  Wind - function (optional). Winds an image into a format ready to be stored by Archivist. If provided, must also provide Unwind.
+--  Unwind - function (optional). Unwinds data stored by Archivist into an image ready to be Opened. If provided, must also provide Wind.
+-- Please note that Create, Open, Update, Commit, Close, Delete, Wind, Unwind may be called at any time if Archivist deems it necessary.
 -- Thus, these methods should ideally be as close to purely functional as is practical, to minimize friction.
 function proto:RegisterStoreType(prototype)
 	checkPrototype(prototype)
@@ -233,7 +237,9 @@ function proto:RegisterStoreType(prototype)
 		Open = prototype.Open,
 		Commit = prototype.Commit,
 		Close = prototype.Close,
-		Delete = prototype.Delete
+		Delete = prototype.Delete,
+		Wind = prototype.Wind,
+		Unwind = prototype.Unwind,
 	}
 	self.activeStores[prototype.id] = self.activeStores[prototype.id] or {}
 	self.sv.stores[prototype.id] = self.sv.stores[prototype.id] or {}
@@ -252,6 +258,33 @@ function proto:RegisterStoreType(prototype)
 	end
 	for storeId in pairs(toOpen) do
 		self:Open(prototype.id, storeId)
+	end
+end
+
+-- produces storable data from image
+function proto:Wind(storeType, image)
+	do -- arg validation
+		self:Assert(type(storeType) == "string" and self.prototypes[storeType], "Store type must be registered before loading data.")
+		self:Assert(image ~= nil, "Cannot wind nil data")
+	end
+
+	if self.prototypes[storeType].Wind then
+		return self.prototypes[storeType]:Wind(image)
+	else
+		return self:Archive(image)
+	end
+end
+
+function proto:Unwind(storeType, woundImage)
+	do -- arg validation
+		self:Assert(type(storeType) == "string" and self.prototypes[storeType], "Store type must be registered before loading data.")
+		self:Assert(woundImage ~= nil, "Cannot unwind nil data")
+	end
+
+	if self.prototypes[storeType].Unwind then
+		return self.prototypes[storeType]:Unwind(woundImage)
+	else
+		return self:DeArchive(woundImage)
 	end
 end
 
@@ -289,7 +322,7 @@ function proto:Create(storeType, id, ...)
 	self.sv.stores[storeType][id] = {
 		timestamp = time(),
 		version = self.prototypes[storeType].version,
-		data = self:Archive(image)
+		data = self:Wind(storeType, image)
 	}
 
 	return store, id
@@ -347,7 +380,7 @@ function proto:Delete(storeType, id, force)
 		if self.prototypes[storeType] and self.prototypes[storeType].Delete and self.sv.stores[storeType][id] then
 			local image = self.activeStores[storeType][id]
 						 and self:Close(self.activeStores[storeType][id])
-						 or self:DeArchive(self.sv.stores[storeType][id].data)
+						 or self:Unwind(storeType, self.sv.stores[storeType][id].data)
 			self.prototypes[storeType]:Delete(image)
 		end
 		self.sv.stores[storeType][id] = nil
@@ -371,13 +404,13 @@ function proto:Open(storeType, id, ...)
 	local store = self.activeStores[storeType][id]
 	if not store then
 		local saved = self.sv.stores[storeType][id]
-		local data = self:DeArchive(saved.data)
+		local data = self:Unwind(saved.data)
 		local prototype = self.prototypes[storeType]
 		-- migrate data...
 		if prototype.Update and prototype.version > saved.version then
 			local newData = prototype:Update(data, saved.version)
 			if newData ~= nil then
-				saved.data = self:Archive(newData)
+				saved.data = self:Wind(storeType, newData)
 				saved.timestamp = time()
 			end
 			saved.version = prototype.version
@@ -426,7 +459,7 @@ function proto:Close(storeType, id)
 	if store then
 		local image = self.prototypes[storeType]:Close(store)
 		if image ~= nil then
-			saved.data = self:Archive(image)
+			saved.data = self:Wind(storeType, image)
 			saved.timestamp = time()
 		end
 		self.activeStores[storeType][id] = nil
@@ -447,7 +480,7 @@ function proto:CloseAllStores()
 			local saved = self.sv.stores[storeType][id]
 			self.activeStores[storeType] = nil
 			if image then
-				saved.data = self:Archive(image)
+				saved.data = self:Wind(storeType,image)
 				saved.timestamp = time()
 			end
 		end
@@ -465,7 +498,7 @@ function proto:Commit(storeType, id)
 	local image = self.prototypes[storeType]:Commit(store)
 	local saved = self.sv.stores[storeType][id]
 	if image ~= nil then
-		saved.data = self:Archive(image)
+		saved.data = self:Wind(storeType, image)
 		saved.timestamp = time()
 	end
 end

--- a/README.md
+++ b/README.md
@@ -167,6 +167,8 @@ local prototpye = {
 	Commit = function(store) end,
 	Close = function(store) end,
 	Delete = function(image) end,
+	Wind = function(image) end,
+	Unwind = function(woundImage) end,
 }
 
 Archivist:RegisterStoreType(prototype)
@@ -193,6 +195,10 @@ Prototype methods:
   - Optional function. If provided, then archived data is replaced with the return value of Update. If no change is needed, then return nil.
 - Commit
   - Return image of data to be archived
+- Wind/Unwind
+  - Optional functions. If provided, these are used instead of Archive/DeArchive to transfer data to/from a storable/openable state.
+  - It is an error to provide one, but not both, of Wind/Unwind.
+  - Useful for when a mixed archive is desirable (e.g. so that the savedvariables are legible without spinning up Archivist for debug/support reasons)
 - Close
   - Deactivate store. Returned value will be written to archive. If no update to archive is needed, then return nil.
   - Once close is called on a store, Archivist will not update the archived data again unless the store is opened.
@@ -286,6 +292,12 @@ store = archive:Clone(storeType, storeID, openStore)
 
 -- Plumbing Methods
 -- 	The following methods are used internally, and are usually not useful for addons using the Archivist.
+
+-- transforms savedvariables data into image suitable for Open()
+image = archive:Unwind(storeType, woundImage)
+
+-- transforms image suitable for Open() into data to be stored in savedvariables
+woundImage = archive:Wind(storetype, image)
 
 -- Generate a random uuid. Used when Create is called without providing a storeID
 uuid = archive:GenerateID()


### PR DESCRIPTION
This idea came to me ~~in a dream~~ after looking over WeakAuras2/WeakAuras#3869, and realizing that part of why archivist feels like it doesn't fit for that use case is because we want the live aura db to be legible in the WTF file (for support & debug reasons mainly).

So, why not teach Archivist how to allow for this?

example implementation


```lua
archive:RegisterStoreType{
  -- ... usual open, create, close, commit
  Wind = function(self, image)
    local wound = CopyTable(image)
    if wound.bigData then
      wound.bigData = self:Archive(wound.bigData)
    end
  return image
  end,
  Unwind = function(self, wound)
    local image = CopyTable(wound)
    if image.bigData then
      image.bigData = self:DeArchive(image.bigData)
    end
  return image
  end
}
```